### PR TITLE
Lines doubled in .node_history

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,20 +9,15 @@ module.exports = function (repl, file) {
   } catch (e) {}
 
   var fd = fs.openSync(file, 'a'), reval = repl.eval;
-
-  repl.eval = function(code, context, file, cb) {
-    var last = code.substring(1)
-    last = last.substring(0, last.length-2);
-
-    if (last && last !== '.history') {
-      fs.write(fd, last + '\n');
+  
+  repl.rli.addListener('line', function(code) {
+    if (code && code !== '.history') {
+      fs.write(fd, code + '\n');
     } else {
       repl.rli.historyIndex++;
       repl.rli.history.pop();
     }
-
-    reval(code, context, file, cb);
-  }
+  });
 
   process.on('exit', function() {
     fs.closeSync(fd);


### PR DESCRIPTION
After entering the following lines in the repl:

```
var x = 123;
console.log(x);
```

My `.node_history` looked like this:

```
var x = 123;
ar x = 123
console.log(x);
onsole.log(x)
```

I believe `eval` gets called twice in order to determine whether the command should span multiple lines.  Rather than overriding `eval` I tried just listening for the `line` event emitted by readline.  Seems to work for me.
