### PR TITLE
.history command should not be declared with a dot

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (repl, file) {
     fs.closeSync(fd);
   });
 
-  repl.commands['.history'] = {
+  repl.commands['history'] = {
     help : 'Show the history',
     action : function() {
       var out = [];


### PR DESCRIPTION
Repl history is accessible through `..history` command, which is inconsistent with other commands that start with only a single dot (`.load`, `.save`).

The `repl` module adds the dot itself: https://github.com/iojs/io.js/blob/ea37ac04f4e4e9248fb361d65a3cd69f57bcaba1/lib/repl.js#L250