### PR TITLE
fix bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (repl, file) {
       fs.write(fd, code + '\n');
     } else {
       repl.rli.historyIndex++;
-      repl.rli.history.pop();
+      repl.rli.history.shift();
     }
   });
 


### PR DESCRIPTION
remove ‘.history’ instead of the earliest record from history array
when trigger ‘line’ event.