### PR TITLE
Adds package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "repl.history",
+  "version": "0.1.4",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
As repl.history has no dependencies this may not be 100% necessary but it does no harm and npm says that you should.

https://docs.npmjs.com/files/package-locks